### PR TITLE
[feature] Button 컴포넌트 및 Storybook 스토리 추가

### DIFF
--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -10,23 +10,30 @@ const meta: Meta<typeof Button> = {
 export default meta;
 type Story = StoryObj<typeof Button>;
 
-export const 전시소개: Story = {
+export const primary: Story = {
   args: {
-    variant: 'exhibition',
-    children: '전시 소개',
+    variant: 'primary',
+    children: '소개 합니다.',
   },
 };
 
-export const 로그인: Story = {
+export const secondary: Story = {
+  args: {
+    variant: 'secondary',
+    children: 'branding',
+  },
+};
+
+export const tertiary: Story = {
+  args: {
+    variant: 'tertiary',
+    children: '전시소개',
+  },
+};
+
+export const login: Story = {
   args: {
     variant: 'login',
     children: '로그인',
-  },
-};
-
-export const 헤더버튼: Story = {
-  args: {
-    variant: 'header',
-    children: '소개 합니다.',
   },
 };

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { Button } from './Button';
+
+const meta: Meta<typeof Button> = {
+  title: 'Components/Button',
+  component: Button,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Button>;
+
+export const 전시소개: Story = {
+  args: {
+    variant: 'exhibition',
+    children: '전시 소개',
+  },
+};
+
+export const 로그인: Story = {
+  args: {
+    variant: 'login',
+    children: '로그인',
+  },
+};
+
+export const 헤더버튼: Story = {
+  args: {
+    variant: 'header',
+    children: '소개 합니다.',
+  },
+};

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,9 +1,9 @@
-// Button.tsx
+import { theme } from '@/styles/theme';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
 export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  variant?: 'exhibition' | 'login' | 'header';
+  variant?: 'primary' | 'secondary' | 'tertiary' | 'login';
   label?: string;
   width?: string | number;
   height?: string | number;
@@ -13,11 +13,19 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
 }
 
 const variantStyles = {
-  exhibition: css`
-    height: 2.3125rem;
-    padding: 0.375rem 1.25rem;
-    gap: 0.625rem;
-    border: 2px solid #F3A;
+  primary: css`
+  padding: 12px 20px;
+  gap: 10px;
+  border: 2px solid #F3A;
+  background: #FFF;
+  color: #F3A;
+
+  &:active {
+    border-color: #FFF;
+    background: #F3A;
+    color: #FFF;
+  }
+`,
     background: #FFF;
     color: #F3A;
     font-size: 1.25rem;
@@ -30,33 +38,27 @@ const variantStyles = {
       color: #FFF;
     }
   `,
-  login: css`
-    width: 29rem;
-    height: 3rem;
-    padding: 0.875rem 6.25rem;
-    gap: 0.625rem;
-    background: #34CD8C;
-    border-radius: 0;
-    color: #FFF;
-    font-size: 1.25rem;
-    font-weight: 700;
-    letter-spacing: -0.025rem;
-  `,
-  header: css`
-    padding: 0.75rem 1.25rem;
-    gap: 0.625rem;
+  tertiary: css`
+    padding: 12px 20px;
+    gap: 10px;
     border: 2px solid #F3A;
     background: #FFF;
     color: #F3A;
-    font-size: 1.25rem;
-    font-weight: 500;
-    letter-spacing: -0.025rem;
 
     &:active {
-      border-color: #FFF;
+      border-color: #FFADEB;
       background: #F3A;
       color: #FFF;
     }
+  `,
+  login: css`
+    width: 464px;
+    height: 48px;
+    padding: 14px 100px;
+    gap: 10px;
+    background: #34CD8C;
+    border-radius: 0;
+    color: #FFF;
   `,
 };
 
@@ -65,11 +67,11 @@ const BaseButton = styled.button<ButtonProps>`
   justify-content: center;
   align-items: center;
   cursor: pointer;
-  font-family: SUITE;
-  font-style: normal;
-  line-height: 130%;
   border-radius: 625rem;
-  border: none;
+  font-size: ${theme.typography.medium.fontSize};
+  font-weight: ${theme.typography.medium.fontWeight};
+  line-height: ${theme.typography.medium.lineHeight};
+  letter-spacing: ${theme.typography.medium.letterSpacing};
 
   ${({ variant }) => variant && variantStyles[variant]}
   ${({ width }) =>
@@ -88,7 +90,7 @@ const BaseButton = styled.button<ButtonProps>`
 export function Button({
   label,
   children,
-  variant = 'exhibition',
+  variant = 'tertiary',
   ...props
 }: ButtonProps) {
   return (

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,0 +1,100 @@
+// Button.tsx
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'exhibition' | 'login' | 'header';
+  label?: string;
+  width?: string | number;
+  height?: string | number;
+  fullWidth?: boolean;
+  style?: React.CSSProperties;
+  children?: React.ReactNode;
+}
+
+const variantStyles = {
+  exhibition: css`
+    height: 2.3125rem;
+    padding: 0.375rem 1.25rem;
+    gap: 0.625rem;
+    border: 2px solid #F3A;
+    background: #FFF;
+    color: #F3A;
+    font-size: 1.25rem;
+    font-weight: 700;
+    letter-spacing: -0.025rem;
+
+    &:active {
+      border-color: #FFADEB;
+      background: #F3A;
+      color: #FFF;
+    }
+  `,
+  login: css`
+    width: 29rem;
+    height: 3rem;
+    padding: 0.875rem 6.25rem;
+    gap: 0.625rem;
+    background: #34CD8C;
+    border-radius: 0;
+    color: #FFF;
+    font-size: 1.25rem;
+    font-weight: 700;
+    letter-spacing: -0.025rem;
+  `,
+  header: css`
+    padding: 0.75rem 1.25rem;
+    gap: 0.625rem;
+    border: 2px solid #F3A;
+    background: #FFF;
+    color: #F3A;
+    font-size: 1.25rem;
+    font-weight: 500;
+    letter-spacing: -0.025rem;
+
+    &:active {
+      border-color: #FFF;
+      background: #F3A;
+      color: #FFF;
+    }
+  `,
+};
+
+const BaseButton = styled.button<ButtonProps>`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+  font-family: SUITE;
+  font-style: normal;
+  line-height: 130%;
+  border-radius: 625rem;
+  border: none;
+
+  ${({ variant }) => variant && variantStyles[variant]}
+  ${({ width }) =>
+    width &&
+    css`
+      width: ${typeof width === 'number' ? `${width}px` : width};
+    `}
+  ${({ height }) =>
+    height &&
+    css`
+      height: ${typeof height === 'number' ? `${height}px` : height};
+    `}
+  ${({ fullWidth }) => fullWidth && `width: 100%;`}
+`;
+
+export function Button({
+  label,
+  children,
+  variant = 'exhibition',
+  ...props
+}: ButtonProps) {
+  return (
+    <BaseButton variant={variant} {...props}>
+      {children ?? label}
+    </BaseButton>
+  );
+}
+

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -26,14 +26,21 @@ const variantStyles = {
     color: #FFF;
   }
 `,
+  secondary: css`
+    width: 245px;
+    padding: 14px 0;
+    gap: 10px;
+    border-radius: 1000px;
+    border: 1px solid #F3A;
     background: #FFF;
     color: #F3A;
-    font-size: 1.25rem;
-    font-weight: 700;
-    letter-spacing: -0.025rem;
+    font-size: ${theme.typography.regular.fontSize};
+    font-weight: ${theme.typography.regular.fontWeight};
+    line-height: ${theme.typography.regular.lineHeight};
+    letter-spacing: ${theme.typography.regular.letterSpacing};
 
     &:active {
-      border-color: #FFADEB;
+      border: 1px solid #FFE8F9;
       background: #F3A;
       color: #FFF;
     }

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -14,16 +14,18 @@ export const theme = {
       fontWeight: 400,
       fontSize: '16px',
       lineHeight: '130%',
+      letterSpacing: '-0.32px',
     },
     medium: {
       fontWeight: 500,
       fontSize: '20px',
       lineHeight: '130%',
+      letterSpacing: '-0.4px',
     },
     bold: {
       fontWeight: 700,
       fontSize: '20px',
-      lineHeight: '130%',
+      lineHeight: '130%',   
     },
   },
 };


### PR DESCRIPTION
# #️⃣연관된 이슈

> ex) #8 


[스토리북 배포링크](https://687f952cbf0b6b7d2e31932f-yjxkspudlc.chromatic.com/?path=/docs/components-button--docs)

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지/동영상 첨부 가능)
### Button 컴포넌트 구현 b43f88c6c23d617025e90d10c15b5cb93c8f369f

- variant: exhibition, login, header 지원
- width, height, fullWidth 등 다양한 props 적용

### Storybook 스토리 추가 add4c64533ee746cc4cff5c408881764399effb4

- 전시소개, 로그인, 헤더버튼 variant별 스토리 작성
- Storybook에서 각 버튼 UI 및 동작 확인 가능


### 추가사항

- primary, secondary, teritiary, login으로 variant 종류 변경
- secondary 버튼 추가

## 중점적으로 리뷰받고 싶은 부분(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 논의하고 싶은 부분(선택)

> 논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항
