### PR TITLE
[feature] 프로젝트 그리드, 썸네일 구현

### DIFF
--- a/src/components/thumbnailGrid/ThumbnailGrid.styles.ts
+++ b/src/components/thumbnailGrid/ThumbnailGrid.styles.ts
@@ -1,0 +1,15 @@
+import styled from '@emotion/styled';
+
+export const Wrapper = styled.div`
+  column-count: 3;
+  column-gap: 50px;
+
+  @media (max-width: ${({ theme }) => theme.breakpoints.mobile}) {
+    column-count: 1;
+  }
+`;
+
+export const ThumbnailContainer = styled.div`
+  break-inside: avoid;
+  margin-bottom: 50px;
+`;

--- a/src/components/thumbnailGrid/ThumbnailGrid.tsx
+++ b/src/components/thumbnailGrid/ThumbnailGrid.tsx
@@ -1,0 +1,30 @@
+import { Thumbnail } from './thumbnail/Thumbnail';
+import * as S from './ThumbnailGrid.styles';
+
+interface Project {
+  title: string;
+  designer: string;
+  imageUrl: string;
+}
+
+interface ThumbnailGridProps {
+  /** 프로젝트 리스트 */
+  projects: Project[];
+}
+
+export const ThumbnailGrid = ({ projects }: ThumbnailGridProps) => {
+  return (
+    <S.Wrapper>
+      {projects.map((project, index) => (
+        <S.ThumbnailContainer key={index}>
+          <Thumbnail
+            title={project.title}
+            designer={project.designer}
+            imageUrl={project.imageUrl}
+            onClick={() => {}}
+          />
+        </S.ThumbnailContainer>
+      ))}
+    </S.Wrapper>
+  );
+};

--- a/src/components/thumbnailGrid/thumbnail/Thumbnail.styles.ts
+++ b/src/components/thumbnailGrid/thumbnail/Thumbnail.styles.ts
@@ -1,0 +1,56 @@
+import styled from '@emotion/styled';
+
+export const Wrapper = styled.div<{ $isBlurred?: boolean }>`
+  position: relative;
+  width: 100%;
+  height: auto;
+  overflow: hidden;
+  cursor: pointer;
+
+  //TODO: 디자인 확인 후 클릭 막기
+  ${({ $isBlurred }) =>
+    $isBlurred &&
+    `
+    opacity: 0.5;
+  `}
+
+  &:hover .overlay {
+    opacity: 1;
+    transform: translateY(0);
+  }
+`;
+
+export const ImageContainer = styled.img`
+  display: block;
+  width: 100%;
+  height: auto;
+  object-fit: cover;
+`;
+
+export const OverlayContainer = styled.div`
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+
+  gap: 16px;
+  background:
+    linear-gradient(180deg, rgba(0, 0, 0, 0.5) 32.84%, rgba(0, 0, 0, 0) 131.35%),
+    linear-gradient(0deg, rgba(0, 0, 0, 0.2) 0%, rgba(0, 0, 0, 0.2) 100%);
+
+  opacity: 0;
+  transition: all 0.3s ease;
+`;
+
+export const TitleContainer = styled.div`
+  ${({ theme }) => theme.typography.bold};
+  color: ${({ theme }) => theme.colors.white};
+`;
+
+export const DesignerContainer = styled.div`
+  ${({ theme }) => theme.typography.medium};
+  color: ${({ theme }) => theme.colors.white};
+`;

--- a/src/components/thumbnailGrid/thumbnail/Thumbnail.tsx
+++ b/src/components/thumbnailGrid/thumbnail/Thumbnail.tsx
@@ -1,0 +1,27 @@
+import * as S from './Thumbnail.styles';
+
+interface ThumbnailProps {
+  title: string;
+  designer: string;
+  imageUrl: string;
+  onClick?: () => void;
+  isBlurred?: boolean;
+}
+
+export const Thumbnail = ({
+  title,
+  designer,
+  imageUrl,
+  onClick,
+  isBlurred = false,
+}: ThumbnailProps) => {
+  return (
+    <S.Wrapper onClick={onClick} $isBlurred={isBlurred}>
+      <S.ImageContainer src={imageUrl} alt={title} />
+      <S.OverlayContainer className="overlay">
+        <S.TitleContainer>{title}</S.TitleContainer>
+        <S.DesignerContainer>{designer}</S.DesignerContainer>
+      </S.OverlayContainer>
+    </S.Wrapper>
+  );
+};

--- a/src/stories/thumbnailList/Thumbnail.stories.tsx
+++ b/src/stories/thumbnailList/Thumbnail.stories.tsx
@@ -1,0 +1,29 @@
+import { Thumbnail } from '@/components/thumbnailGrid/thumbnail/Thumbnail';
+import type { Meta, StoryObj } from '@storybook/nextjs';
+
+const meta: Meta<typeof Thumbnail> = {
+  title: 'Components/ThumbnailList/Thumbnail',
+  component: Thumbnail,
+};
+
+export default meta;
+type Story = StoryObj<typeof Thumbnail>;
+
+export const Default: Story = {
+  args: {
+    title: '프로젝트 제목',
+    designer: '디자이너 이름',
+    imageUrl: 'https://i.pinimg.com/1200x/69/26/1b/69261bec7bcf155e6501475eccd7dc31.jpg',
+    onClick: () => {},
+  },
+};
+
+export const Blurred: Story = {
+  args: {
+    title: '프로젝트 제목',
+    designer: '디자이너 이름',
+    imageUrl: 'https://i.pinimg.com/1200x/69/26/1b/69261bec7bcf155e6501475eccd7dc31.jpg',
+    onClick: () => {},
+    isBlurred: true,
+  },
+};

--- a/src/stories/thumbnailList/ThumbnailGrid.stories.tsx
+++ b/src/stories/thumbnailList/ThumbnailGrid.stories.tsx
@@ -1,0 +1,121 @@
+import { ThumbnailGrid } from '@/components/thumbnailGrid/ThumbnailGrid';
+import type { Meta, StoryObj } from '@storybook/nextjs';
+
+const meta: Meta<typeof ThumbnailGrid> = {
+  title: 'Components/ThumbnailList/ThumbnailGrid',
+  component: ThumbnailGrid,
+};
+
+export default meta;
+type Story = StoryObj<typeof ThumbnailGrid>;
+
+const mockUrl = 'https://i.pinimg.com/1200x/69/26/1b/69261bec7bcf155e6501475eccd7dc31.jpg';
+
+const projects = [
+  {
+    title: '자연 속의 균형',
+    designer: '김하늘',
+    imageUrl: 'https://i.pinimg.com/1200x/10/f2/79/10f2790442d741279c5bfc9795b3ebb3.jpg',
+  },
+  {
+    title: '도시의 리듬',
+    designer: '이준호',
+    imageUrl: 'https://i.pinimg.com/1200x/4b/a8/27/4ba8272cae940dba0f5c382f4d7e36ca.jpg',
+  },
+  {
+    title: '몽환적인 기억',
+    designer: '박서연',
+    imageUrl: mockUrl,
+  },
+  {
+    title: '복잡한 단순함',
+    designer: '최지우',
+    imageUrl: 'https://i.pinimg.com/1200x/10/f2/79/10f2790442d741279c5bfc9795b3ebb3.jpg',
+  },
+  {
+    title: '빛과 그림자',
+    designer: '정민재',
+    imageUrl: mockUrl,
+  },
+  {
+    title: '공간의 재구성',
+    designer: '오하늘',
+    imageUrl: 'https://i.pinimg.com/1200x/4b/a8/27/4ba8272cae940dba0f5c382f4d7e36ca.jpg',
+  },
+  {
+    title: '움직임의 미학',
+    designer: '윤도윤',
+    imageUrl: 'https://i.pinimg.com/736x/ee/9f/30/ee9f30919ac7c4e20eff5227acb30781.jpg',
+  },
+  {
+    title: '미래의 전통',
+    designer: '한소연',
+    imageUrl: mockUrl,
+  },
+  {
+    title: '자연과 인간',
+    designer: '김수진',
+    imageUrl: 'https://i.pinimg.com/1200x/4b/a8/27/4ba8272cae940dba0f5c382f4d7e36ca.jpg',
+  },
+  {
+    title: '감정의 색',
+    designer: '배지훈',
+    imageUrl: 'https://i.pinimg.com/1200x/4b/a8/27/4ba8272cae940dba0f5c382f4d7e36ca.jpg',
+  },
+  {
+    title: '순환의 구조',
+    designer: '이예린',
+    imageUrl: mockUrl,
+  },
+  {
+    title: '일상의 재발견',
+    designer: '조민호',
+    imageUrl: 'https://i.pinimg.com/736x/ee/9f/30/ee9f30919ac7c4e20eff5227acb30781.jpg',
+  },
+  {
+    title: '디지털 감성',
+    designer: '김다영',
+    imageUrl: mockUrl,
+  },
+  {
+    title: '기억의 파편',
+    designer: '최준혁',
+    imageUrl: mockUrl,
+  },
+  {
+    title: '추상의 실체',
+    designer: '박지윤',
+    imageUrl: 'https://i.pinimg.com/736x/ee/9f/30/ee9f30919ac7c4e20eff5227acb30781.jpg',
+  },
+  {
+    title: '파괴와 창조',
+    designer: '이재민',
+    imageUrl: mockUrl,
+  },
+  {
+    title: '숨겨진 질서',
+    designer: '서유리',
+    imageUrl: mockUrl,
+  },
+  {
+    title: '감각의 충돌',
+    designer: '노진우',
+    imageUrl: mockUrl,
+  },
+  {
+    title: '시간의 흐름',
+    designer: '황예나',
+    imageUrl: mockUrl,
+  },
+  {
+    title: '다층적 시선',
+    designer: '백승현',
+    imageUrl: mockUrl,
+  },
+];
+
+export const Default: Story = {
+  args: {
+    projects: projects,
+  },
+};


### PR DESCRIPTION
# #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#13 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지/동영상 첨부 가능)

[스토리북](https://687f952cbf0b6b7d2e31932f-drrerwswrd.chromatic.com/)

- 썸네일 컴포넌트를 제작하였습니다.
- 프로젝트 그리드를 Masonry grid로 구현하였습니다.

## 🫡 참고사항

<img width="706" height="532" alt="image" src="https://github.com/user-attachments/assets/73f3232d-d691-4461-833f-29b2de9b37de" />

- 검색에 따라 blur을 넣는 케이스가 존재하는데, 이 경우 click을 막을 것인지에 대해 정해지지 않아, 추후 수정이 필요합니다.