### PR TITLE
[feature] 캐러셀 컴포넌트 구현

### DIFF
--- a/src/components/carousel/Carousel.styles.ts
+++ b/src/components/carousel/Carousel.styles.ts
@@ -1,0 +1,48 @@
+import styled from '@emotion/styled';
+
+export const Wrapper = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 30px;
+  overflow: hidden;
+`;
+
+export const SlidesContainer = styled.div<{ $currentIndex: number; $isTransitioning: boolean }>`
+  display: flex;
+  width: 100%;
+  transform: translateX(${({ $currentIndex }) => `-${$currentIndex * 100}%`});
+  transition: ${({ $isTransitioning }) =>
+    $isTransitioning ? 'transform 0.4s ease-in-out' : 'none'};
+`;
+
+export const ImageContainer = styled.img`
+  flex: 0 0 100%;
+  width: 100%;
+  height: auto;
+  object-fit: cover;
+  display: block;
+`;
+
+export const VideoContainer = styled.iframe`
+  flex: 0 0 100%;
+  width: 100%;
+  height: auto;
+  object-fit: cover;
+  display: block;
+`;
+
+export const DotsContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  gap: 24px;
+`;
+
+export const DotContainer = styled.div<{ $isActive: boolean }>`
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background-color: ${({ $isActive }) => ($isActive ? '#666666' : '#D9D9D9')};
+  border: none;
+  cursor: pointer;
+`;

--- a/src/components/carousel/Carousel.tsx
+++ b/src/components/carousel/Carousel.tsx
@@ -1,0 +1,70 @@
+import { Slide } from '@/types/slide.type';
+import { useCallback, useEffect, useState } from 'react';
+import * as S from './Carousel.styles';
+
+interface CarouselProps {
+  /** 슬라이드 Url */
+  slides: Slide[];
+}
+
+export const Carousel = ({ slides }: CarouselProps) => {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [isTransitioning, setIsTransitioning] = useState(true);
+  const extendedSlides = [...slides, slides[0]];
+
+  const goToSlide = (index: number) => {
+    const nextIndex =
+      (index + extendedSlides.length) % extendedSlides.length === 0
+        ? extendedSlides.length - 1
+        : (index + extendedSlides.length) % extendedSlides.length;
+    setCurrentIndex(nextIndex);
+  };
+
+  const resetIndexAndTransition = useCallback(() => {
+    setTimeout(() => {
+      setCurrentIndex(0);
+      setIsTransitioning(false);
+    }, 1);
+  }, []);
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      if (currentIndex === extendedSlides.length - 1) {
+        resetIndexAndTransition();
+      }
+      setCurrentIndex(prev => (prev + 1) % extendedSlides.length);
+      setIsTransitioning(true);
+    }, 2500);
+
+    return () => clearInterval(timer);
+  }, [currentIndex, extendedSlides.length, resetIndexAndTransition]);
+
+  return (
+    <S.Wrapper>
+      <S.SlidesContainer $currentIndex={currentIndex} $isTransitioning={isTransitioning}>
+        {extendedSlides.map((slide, index) =>
+          slide.type === 'image' ? (
+            <S.ImageContainer key={index} src={slide.url} />
+          ) : (
+            <S.VideoContainer
+              key={index}
+              src={slide.url}
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowFullScreen
+              loading="lazy"
+            />
+          ),
+        )}
+      </S.SlidesContainer>
+      <S.DotsContainer>
+        {slides.map((_, index) => (
+          <S.DotContainer
+            key={index}
+            onClick={() => goToSlide(index)}
+            $isActive={currentIndex === slides.length ? index === 0 : index === currentIndex}
+          />
+        ))}
+      </S.DotsContainer>
+    </S.Wrapper>
+  );
+};

--- a/src/components/carousel/Carousel.tsx
+++ b/src/components/carousel/Carousel.tsx
@@ -5,42 +5,65 @@ import * as S from './Carousel.styles';
 interface CarouselProps {
   /** 슬라이드 Url */
   slides: Slide[];
+  /** 커서가 들어오면 일시정지 */
+  pauseOnHover?: boolean;
 }
 
-export const Carousel = ({ slides }: CarouselProps) => {
+export const Carousel = ({ slides, pauseOnHover = true }: CarouselProps) => {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [isTransitioning, setIsTransitioning] = useState(true);
+  const [isPaused, setIsPaused] = useState(false);
   const extendedSlides = [...slides, slides[0]];
+  const lastIndex = extendedSlides.length - 1;
+  const displayIndex = currentIndex === lastIndex ? 0 : currentIndex;
+
+  const snapTo = (index: number) => {
+    setIsTransitioning(false);
+    setCurrentIndex(index);
+  };
+
+  const animateTo = (index: number) => {
+    setIsTransitioning(true);
+    setCurrentIndex(index);
+  };
 
   const goToSlide = (index: number) => {
-    const nextIndex =
-      (index + extendedSlides.length) % extendedSlides.length === 0
-        ? extendedSlides.length - 1
-        : (index + extendedSlides.length) % extendedSlides.length;
-    setCurrentIndex(nextIndex);
+    if (currentIndex === lastIndex && index !== 0) {
+      snapTo(0);
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          animateTo(index);
+        });
+      });
+      return;
+    }
+
+    animateTo(index);
   };
 
   const resetIndexAndTransition = useCallback(() => {
     setTimeout(() => {
-      setCurrentIndex(0);
-      setIsTransitioning(false);
+      snapTo(0);
     }, 1);
   }, []);
 
   useEffect(() => {
+    if (isPaused) return;
     const timer = setInterval(() => {
-      if (currentIndex === extendedSlides.length - 1) {
+      if (currentIndex === lastIndex) {
         resetIndexAndTransition();
       }
-      setCurrentIndex(prev => (prev + 1) % extendedSlides.length);
-      setIsTransitioning(true);
+      animateTo((prev => (prev + 1) % extendedSlides.length)(currentIndex));
     }, 2500);
 
     return () => clearInterval(timer);
-  }, [currentIndex, extendedSlides.length, resetIndexAndTransition]);
+  }, [currentIndex, extendedSlides.length, lastIndex, resetIndexAndTransition, isPaused]);
 
   return (
-    <S.Wrapper>
+    <S.Wrapper
+      onMouseEnter={() => pauseOnHover && setIsPaused(true)}
+      onMouseLeave={() => pauseOnHover && setIsPaused(false)}
+    >
       <S.SlidesContainer $currentIndex={currentIndex} $isTransitioning={isTransitioning}>
         {extendedSlides.map((slide, index) =>
           slide.type === 'image' ? (
@@ -61,7 +84,7 @@ export const Carousel = ({ slides }: CarouselProps) => {
           <S.DotContainer
             key={index}
             onClick={() => goToSlide(index)}
-            $isActive={currentIndex === slides.length ? index === 0 : index === currentIndex}
+            $isActive={displayIndex === index}
           />
         ))}
       </S.DotsContainer>

--- a/src/stories/Carousel.stories.tsx
+++ b/src/stories/Carousel.stories.tsx
@@ -1,0 +1,40 @@
+import { Carousel } from '@/components/carousel/Carousel';
+import { Slide } from '@/types/slide.type';
+import type { Meta, StoryObj } from '@storybook/nextjs';
+
+const meta: Meta<typeof Carousel> = {
+  title: 'Components/Carousel',
+  component: Carousel,
+};
+
+export default meta;
+type Story = StoryObj<typeof Carousel>;
+
+const mockSlides: Slide[] = [
+  {
+    type: 'image',
+    url: 'https://i.pinimg.com/1200x/17/46/44/174644133c847070b82422e6078e3ee5.jpg',
+  },
+  {
+    type: 'image',
+    url: 'https://i.pinimg.com/1200x/02/a4/e0/02a4e08f327dcc7b7834f9d6e24420ba.jpg',
+  },
+  {
+    type: 'image',
+    url: 'https://i.pinimg.com/1200x/c1/56/d2/c156d2f0330ac8da3ef2edbe750cc186.jpg',
+  },
+  {
+    type: 'image',
+    url: 'https://i.pinimg.com/1200x/15/2f/0e/152f0ef26def17c842167ebd61dfc1a8.jpg',
+  },
+  {
+    type: 'video',
+    url: 'https://www.youtube.com/embed/ToUvNWlfAu0?si=s1vLFEEhAinOk2tx&amp;start=2684',
+  },
+];
+
+export const Default: Story = {
+  args: {
+    slides: mockSlides,
+  },
+};

--- a/src/types/slide.type.ts
+++ b/src/types/slide.type.ts
@@ -1,0 +1,4 @@
+export interface Slide {
+  type: 'image' | 'video';
+  url: string;
+}


### PR DESCRIPTION
# #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#14 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지/동영상 첨부 가능)

[스토리북](https://687f952cbf0b6b7d2e31932f-ilqrevubgd.chromatic.com/)

2.5초(2500ms)마다 자동 전환되는 캐러셀을 구현하였습니다.
이미지와 YouTube 형식의 비디오를 모두 지원하도록 구성하였습니다.
업로드 이미지의 비율은 정해져있을 거라고 생각해서 따로 width, height를 고정값을 두지는 않았습니다. 따라서 스토리북으로 보실 때 크게 느껴지실 수 있습니다.

상세 페이지 작업할 때, Layout으로 컴포넌트 크기를 조절하면 될 것 같습니다.

## 논의하고 싶은 부분

> 논의하고 싶은 부분이 있다면 작성해주세요.

https://github.com/user-attachments/assets/eeb72a7b-48e8-431a-8c80-775fe4585cac

- 현재는 YouTube 영상을 <iframe>으로 임베드하여 재생할 수 있도록 구현하였습니다.

- 예상되는 문제는 이미지와 영상이 함께 있는 경우, 캐러셀이 자동으로 전환되기 때문에 영상 재생 중에도 화면이 넘어간다는 점입니다.

- 이번 구현은 동영상이 단독으로 삽입된 경우를 기준으로 설계했으며, 이미지와 혼합된 케이스는 추후 대응해야할 수 있습니다.

- 유튜브 API를 통해 재생 상태를 제어하거나, 클릭 이벤트 등을 활용해 UX를 개선할 수 있지만, 현시점에서는 우선 업로드 포맷 및 사용 사례를 먼저 파악한 후, 그에 맞는 UX 개선 방향을 잡는 것이 더 적절하다고 판단했습니다.

위 문제에 대해서 우선적으로 대응해두는 것이 좋을까요??